### PR TITLE
Fix builds after tungstenite 0.20.1

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -70,6 +70,74 @@ jobs:
         env:
           RUSTFLAGS: -D warnings
 
+  check_windows:
+    name: Check Windows builds
+    needs: clippy
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        etl:
+          [
+            "--features etl_native_tls",
+            "--features etl_rustls",
+            "--features etl",
+            "",
+          ]
+        compression: ["--features compression", ""]
+        migrate: ["--features migrate", ""]
+        extra_datatypes: ["--features rust_decimal,uuid,chrono", ""]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --tests ${{ matrix.etl }} ${{ matrix.migrate }} ${{ matrix.compression }} ${{ matrix.extra_datatypes }}
+
+  check_mac_os:
+    name: Check MacOS builds
+    needs: clippy
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        etl:
+          [
+            "--features etl_native_tls",
+            "--features etl_rustls",
+            "--features etl",
+            "",
+          ]
+        compression: ["--features compression", ""]
+        migrate: ["--features migrate", ""]
+        extra_datatypes: ["--features rust_decimal,uuid,chrono", ""]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --tests ${{ matrix.etl }} ${{ matrix.migrate }} ${{ matrix.compression }} ${{ matrix.extra_datatypes }}
+
   connection_tests:
     name: Connection tests
     needs: clippy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@ All notable changes to this project will be documented in this file.
  
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [0.7.1-alpha-4] - 2023-10-26
+
+### Added
+ 
+- [#18](https://github.com/bobozaur/sqlx-exasol/pull/18): `cargo check` CI jobs for Windows and MacOS.
+
+### Fixed
+
+- [#17](https://github.com/bobozaur/sqlx-exasol/issues/17) Fixed building the library after 
+[CVE-2023-43669](https://nvd.nist.gov/vuln/detail/CVE-2023-43669) update of `tungstenite` to version `0.20.1`.
  
 ## [0.7.1-alpha-3] - 2023-09-13
  

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ sqlx-macros-core = "=0.7.1"
 tracing = { version = "0.1.37", features = ["log"] }
 arrayvec = "0.7.4"
 rcgen = { version = "0.11.1", optional = true }
+tungstenite = "0.20.1"
 
 # Feature flagged optional dependencies
 uuid = { version = "1.4.1", features = ["serde"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlx-exasol"
-version = "0.7.1-alpha-3"
+version = "0.7.1-alpha-4"
 edition = "2021"
 authors = ["bobozaur"]
 description = "Exasol driver for the SQLx framework."

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Inspired by [Py-Exasol](https://github.com/exasol/pyexasol) and based on the (no
 > With that in mind, please favor using a fixed version of `sqlx` and `sqlx-exasol` in `Cargo.toml` to avoid issues, such as:
 > ```toml
 > sqlx = "=0.7.1"
-> sqlx-exasol = "=0.7.1-alpha-3"
+> sqlx-exasol = "=0.7.1-alpha-4"
 > ```
 
 

--- a/src/connection/websocket/mod.rs
+++ b/src/connection/websocket/mod.rs
@@ -255,7 +255,7 @@ impl ExaWebSocket {
 
         // Run batch SQL command
         match self.send_cmd_ignore_response(cmd).await {
-            Ok(_) => return Ok(()),
+            Ok(()) => return Ok(()),
             Err(e) => tracing::warn!(
                 "failed to execute batch SQL: {e}; will attempt sequential execution"
             ),

--- a/src/error.rs
+++ b/src/error.rs
@@ -51,6 +51,7 @@ impl<T> ExaResultExt<T> for Result<T, WsError> {
             Ok(v) => return Ok(v),
             Err(e) => e,
         };
+
         let e = match e {
             WsError::ConnectionClosed => SqlxError::Protocol(WsError::ConnectionClosed.to_string()),
             WsError::AlreadyClosed => SqlxError::Protocol(WsError::AlreadyClosed.to_string()),
@@ -63,6 +64,7 @@ impl<T> ExaResultExt<T> for Result<T, WsError> {
             WsError::Url(e) => SqlxError::Configuration(e.into()),
             WsError::Http(r) => SqlxError::Protocol(format!("HTTP error: {}", r.status())),
             WsError::HttpFormat(e) => SqlxError::Protocol(e.to_string()),
+            WsError::AttackAttempt => SqlxError::Tls(WsError::AttackAttempt.into()),
         };
 
         Err(e)


### PR DESCRIPTION
`async-tungstenite` imports the minor version of `tungstenite` (`0.20` at the time of this PR).

The `sqlx-exasol` library was developed according to `tungstenite` version `0.20.0` but after [CVE-2023-43669](https://nvd.nist.gov/vuln/detail/CVE-2023-43669) version `0.20.1` was released, and that was making builds fail. The issue #17 uncovered this as part of a Windows build, but it in fact affects all OS's.

This PR imports a fixed version of `tungstenite` (`0.20.1`) and accommodates the added error variant as part of the vulnerability fix.

Additionally, for the sake of ensuring builds, `cargo check` CI jobs were added to build the library on Windows and MacOS.