### PR TITLE
Update to sqlx 0.7.2

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -74,18 +74,6 @@ jobs:
     name: Check Windows builds
     needs: clippy
     runs-on: windows-latest
-    strategy:
-      matrix:
-        etl:
-          [
-            "--features etl_native_tls",
-            "--features etl_rustls",
-            "--features etl",
-            "",
-          ]
-        compression: ["--features compression", ""]
-        migrate: ["--features migrate", ""]
-        extra_datatypes: ["--features rust_decimal,uuid,chrono", ""]
     steps:
       - uses: actions/checkout@v3
 
@@ -95,31 +83,18 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-          components: clippy
 
       - uses: Swatinem/rust-cache@v2
 
       - uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --tests ${{ matrix.etl }} ${{ matrix.migrate }} ${{ matrix.compression }} ${{ matrix.extra_datatypes }}
+          args: --tests --features compression,migrate,etl,rust_decimal,uuid,chrono
 
   check_mac_os:
     name: Check MacOS builds
     needs: clippy
     runs-on: macos-latest
-    strategy:
-      matrix:
-        etl:
-          [
-            "--features etl_native_tls",
-            "--features etl_rustls",
-            "--features etl",
-            "",
-          ]
-        compression: ["--features compression", ""]
-        migrate: ["--features migrate", ""]
-        extra_datatypes: ["--features rust_decimal,uuid,chrono", ""]
     steps:
       - uses: actions/checkout@v3
 
@@ -129,14 +104,13 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-          components: clippy
 
       - uses: Swatinem/rust-cache@v2
 
       - uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --tests ${{ matrix.etl }} ${{ matrix.migrate }} ${{ matrix.compression }} ${{ matrix.extra_datatypes }}
+          args: --tests --features compression,migrate,etl,rust_decimal,uuid,chrono
 
   connection_tests:
     name: Connection tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.7.2] - 2023-11-20
+
+### Added
+ 
+- [#19](https://github.com/bobozaur/sqlx-exasol/pull/19): Update to sqlx `0.7.2`.
+
+### Fixed
+
+- [#19](https://github.com/bobozaur/sqlx-exasol/pull/19): README fixes.
+
 ## [0.7.1-alpha-4] - 2023-10-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
  
-- [#21](https://github.com/bobozaur/sqlx-exasol/pull/21): Update to sqlx `0.7.2`.
+- [#21](https://github.com/bobozaur/sqlx-exasol/pull/21): Update to sqlx `0.7.2`; Simplified Windows and MacOS `cargo check`jobs.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- [#14](https://github.com/bobozaur/sqlx-exasol/issues/14): Simplify `ExaSocket` `AsyncWrite::poll_flush()` impl.
 - [#19](https://github.com/bobozaur/sqlx-exasol/pull/19): README fixes.
 
 ## [0.7.1-alpha-4] - 2023-10-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
  
-- [#19](https://github.com/bobozaur/sqlx-exasol/pull/19): Update to sqlx `0.7.2`.
+- [#21](https://github.com/bobozaur/sqlx-exasol/pull/21): Update to sqlx `0.7.2`.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlx-exasol"
-version = "0.7.1-alpha-4"
+version = "0.7.2"
 edition = "2021"
 authors = ["bobozaur"]
 description = "Exasol driver for the SQLx framework."
@@ -44,9 +44,9 @@ futures-core = "0.3.28"
 serde_json = { version = "1.0.100", features = ["raw_value"] }
 serde = { version = "1.0.169", features = ["derive"] }
 pin-project = "1.1.2"
-lru = "0.11.0"
-sqlx-core = "=0.7.1"
-sqlx-macros-core = "=0.7.1"
+lru = "0.12.0"
+sqlx-core = "0.7.2"
+sqlx-macros-core = "0.7.2"
 tracing = { version = "0.1.37", features = ["log"] }
 arrayvec = "0.7.4"
 rcgen = { version = "0.11.1", optional = true }
@@ -70,7 +70,7 @@ rustls = { version = "0.21", default-features = false, features = [
 native-tls = { version = "0.2.10", optional = true }
 
 [dev-dependencies]
-sqlx = { version = "=0.7.1", features = [
+sqlx = { version = "0.7.2", features = [
     "runtime-tokio",
     "tls-native-tls",
     "migrate",

--- a/README.md
+++ b/README.md
@@ -8,14 +8,12 @@ Inspired by [Py-Exasol](https://github.com/exasol/pyexasol) and based on the (no
 **MSRV**: `1.70`
 
 ## Note
->The driver is currently in its `alpha` stage. This will change when it's seen some usage and seems mature enough to be declared **stable**.  
->
-> For simplicity, the crate's version resembles the `sqlx` version it is based on so that managing dependencies is simpler.   
+>The crate's version resembles the `sqlx` version it is based on so that managing dependencies is simpler.   
 >
 > With that in mind, please favor using a fixed version of `sqlx` and `sqlx-exasol` in `Cargo.toml` to avoid issues, such as:
 > ```toml
-> sqlx = "=0.7.1"
-> sqlx-exasol = "=0.7.1-alpha-4"
+> sqlx = "=0.7.2"
+> sqlx-exasol = "=0.7.2"
 > ```
 
 

--- a/src/connection/etl/export/reader.rs
+++ b/src/connection/etl/export/reader.rs
@@ -26,7 +26,7 @@ pub struct ExportReader {
 
 impl ExportReader {
     /// HTTP Response for the EXPORT request Exasol sends.
-    const RESPONSE: &[u8; 38] = b"HTTP/1.1 200 OK\r\n\
+    const RESPONSE: &'static [u8; 38] = b"HTTP/1.1 200 OK\r\n\
                                   Connection: close\r\n\
                                   \r\n";
 

--- a/src/connection/etl/import/writer.rs
+++ b/src/connection/etl/import/writer.rs
@@ -43,10 +43,10 @@ impl ImportWriter {
     // In HEX, that's 8 bytes -> 16 digits.
     // We also reserve two additional bytes for CRLF.
     const CHUNK_SIZE_RESERVED: usize = 18;
-    const EMPTY_CHUNK: &[u8; 5] = b"0\r\n\r\n";
+    const EMPTY_CHUNK: &'static [u8; 5] = b"0\r\n\r\n";
 
     /// HTTP Response for the IMPORT request Exasol sends.
-    const RESPONSE: &[u8; 66] = b"HTTP/1.1 200 OK\r\n\
+    const RESPONSE: &'static [u8; 66] = b"HTTP/1.1 200 OK\r\n\
                                   Connection: close\r\n\
                                   Transfer-Encoding: chunked\r\n\
                                   \r\n";

--- a/src/connection/websocket/mod.rs
+++ b/src/connection/websocket/mod.rs
@@ -38,8 +38,8 @@ pub struct ExaWebSocket {
 }
 
 impl ExaWebSocket {
-    const WS_SCHEME: &str = "ws";
-    const WSS_SCHEME: &str = "wss";
+    const WS_SCHEME: &'static str = "ws";
+    const WSS_SCHEME: &'static str = "wss";
 
     pub(crate) async fn new(
         host: &str,

--- a/src/connection/websocket/socket.rs
+++ b/src/connection/websocket/socket.rs
@@ -79,9 +79,7 @@ impl AsyncWrite for ExaSocket {
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<IoResult<()>> {
-        // The `as_mut()` call is VERY important as currently
-        // Box<dyn Stream> does not override the `poll_flush()` method.
-        self.inner.as_mut().poll_flush(cx)
+        self.inner.poll_flush(cx)
     }
 
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<IoResult<()>> {

--- a/src/options/serializable.rs
+++ b/src/options/serializable.rs
@@ -31,8 +31,8 @@ struct LoginAttrs<'a> {
 }
 
 impl<'a> SerializableConOpts<'a> {
-    const CLIENT_RUNTIME: &str = "Rust";
-    const CLIENT_NAME: &str = "Rust Exasol";
+    const CLIENT_RUNTIME: &'static str = "Rust";
+    const CLIENT_NAME: &'static str = "Rust Exasol";
 }
 
 impl<'a> From<ExaConnectOptionsRef<'a>> for SerializableConOpts<'a> {

--- a/src/type_info.rs
+++ b/src/type_info.rs
@@ -100,19 +100,19 @@ pub enum ExaDataType {
 }
 
 impl ExaDataType {
-    const NULL: &str = "NULL";
-    const BOOLEAN: &str = "BOOLEAN";
-    const CHAR: &str = "CHAR";
-    const DATE: &str = "DATE";
-    const DECIMAL: &str = "DECIMAL";
-    const DOUBLE: &str = "DOUBLE PRECISION";
-    const GEOMETRY: &str = "GEOMETRY";
-    const INTERVAL_DAY_TO_SECOND: &str = "INTERVAL DAY TO SECOND";
-    const INTERVAL_YEAR_TO_MONTH: &str = "INTERVAL YEAR TO MONTH";
-    const TIMESTAMP: &str = "TIMESTAMP";
-    const TIMESTAMP_WITH_LOCAL_TIME_ZONE: &str = "TIMESTAMP WITH LOCAL TIME ZONE";
-    const VARCHAR: &str = "VARCHAR";
-    const HASHTYPE: &str = "HASHTYPE";
+    const NULL: &'static str = "NULL";
+    const BOOLEAN: &'static str = "BOOLEAN";
+    const CHAR: &'static str = "CHAR";
+    const DATE: &'static str = "DATE";
+    const DECIMAL: &'static str = "DECIMAL";
+    const DOUBLE: &'static str = "DOUBLE PRECISION";
+    const GEOMETRY: &'static str = "GEOMETRY";
+    const INTERVAL_DAY_TO_SECOND: &'static str = "INTERVAL DAY TO SECOND";
+    const INTERVAL_YEAR_TO_MONTH: &'static str = "INTERVAL YEAR TO MONTH";
+    const TIMESTAMP: &'static str = "TIMESTAMP";
+    const TIMESTAMP_WITH_LOCAL_TIME_ZONE: &'static str = "TIMESTAMP WITH LOCAL TIME ZONE";
+    const VARCHAR: &'static str = "VARCHAR";
+    const HASHTYPE: &'static str = "HASHTYPE";
 
     /// Returns `true` if this instance is compatible with the other one provided.
     ///


### PR DESCRIPTION
Encapsulates #19.
Fixes #14.
Addresses #20.
Updates library to `0.7.2` to follow `sqlx`.