### PR TITLE
Executor improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
 
-      - uses: dtolnay/rust-toolchain@1.82.0
+      - uses: dtolnay/rust-toolchain@1.85.0
         with:
           components: clippy
 
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
 
-      - uses: dtolnay/rust-toolchain@1.82.0
+      - uses: dtolnay/rust-toolchain@1.85.0
         with:
           components: clippy
 
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
 
-      - uses: dtolnay/rust-toolchain@1.82.0
+      - uses: dtolnay/rust-toolchain@1.85.0
         with:
           components: clippy
 
@@ -112,7 +112,7 @@ jobs:
           exasol-version: ${{ env.EXASOL_VERSION }}
           num-nodes: ${{ env.NUM_NODES }}
 
-      - uses: dtolnay/rust-toolchain@1.82.0
+      - uses: dtolnay/rust-toolchain@1.85.0
       - uses: Swatinem/rust-cache@v2
 
       - name: Connection tests
@@ -146,7 +146,7 @@ jobs:
           exasol-version: ${{ env.EXASOL_VERSION }}
           num-nodes: ${{ env.NUM_NODES }}
 
-      - uses: dtolnay/rust-toolchain@1.82.0
+      - uses: dtolnay/rust-toolchain@1.85.0
       - uses: Swatinem/rust-cache@v2
 
       - name: TLS connection tests
@@ -180,7 +180,7 @@ jobs:
           exasol-version: ${{ env.EXASOL_VERSION }}
           num-nodes: ${{ env.NUM_NODES }}
 
-      - uses: dtolnay/rust-toolchain@1.82.0
+      - uses: dtolnay/rust-toolchain@1.85.0
       - uses: Swatinem/rust-cache@v2
 
       - name: ETL tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- [#33](https://github.com/bobozaur/sqlx-exasol/pull/33): Avoid nested boxing in Executor impl
+
 ## [0.8.6] - 2025-06-03
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "sqlx-exasol"
 version = "0.8.6"
-edition = "2021"
+edition = "2024"
 authors = ["bobozaur"]
-rust-version = "1.82.0"
+rust-version = "1.85.0"
 description = "Exasol driver for the SQLx framework."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bobozaur/sqlx-exasol"

--- a/src/connection/etl/export/options.rs
+++ b/src/connection/etl/export/options.rs
@@ -111,7 +111,7 @@ impl<'a> ExportBuilder<'a> {
     }
 }
 
-impl<'a> EtlJob for ExportBuilder<'a> {
+impl EtlJob for ExportBuilder<'_> {
     const JOB_TYPE: &'static str = "export";
 
     type Worker = ExaExport;

--- a/src/connection/etl/import/options.rs
+++ b/src/connection/etl/import/options.rs
@@ -134,7 +134,7 @@ impl<'a> ImportBuilder<'a> {
     }
 }
 
-impl<'a> EtlJob for ImportBuilder<'a> {
+impl EtlJob for ImportBuilder<'_> {
     const JOB_TYPE: &'static str = "import";
 
     type Worker = ExaImport;

--- a/src/connection/etl/mod.rs
+++ b/src/connection/etl/mod.rs
@@ -130,7 +130,7 @@ impl AsRef<str> for RowSeparator {
 #[derive(Debug)]
 pub struct EtlQuery<'c>(ExaFuture<'c, ExecuteEtl>);
 
-impl<'c> Future for EtlQuery<'c> {
+impl Future for EtlQuery<'_> {
     type Output = SqlxResult<ExaQueryResult>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {

--- a/src/connection/etl/tls/mod.rs
+++ b/src/connection/etl/tls/mod.rs
@@ -24,6 +24,7 @@ pub fn with_worker() -> SqlxResult<impl WithWorker> {
 
     use crate::error::ToSqlxError;
 
+    #[expect(non_local_definitions, reason = "conditionally compiled")]
     impl ToSqlxError for rcgen::Error {
         fn to_sqlx_err(self) -> SqlxError {
             SqlxError::Tls(self.into())

--- a/src/connection/executor.rs
+++ b/src/connection/executor.rs
@@ -29,7 +29,7 @@ impl<'c> Executor<'c> for &'c mut ExaConnection {
         'c: 'e,
         E: 'q + Execute<'q, Exasol>,
     {
-        match self._fetch(query) {
+        match self.fetch_impl(query) {
             Ok(stream) => stream
                 .try_filter_map(|v| std::future::ready(Ok(v.left())))
                 .try_collect()
@@ -44,11 +44,11 @@ impl<'c> Executor<'c> for &'c mut ExaConnection {
         'c: 'e,
         E: 'q + Execute<'q, Exasol>,
     {
-        match self._fetch_many(query) {
+        match self.fetch_many_impl(query) {
             Ok(stream) => stream
                 .try_filter_map(|step| std::future::ready(Ok(step.left())))
                 .boxed(),
-            Err(e) => return std::future::ready(Err(e)).into_stream().boxed(),
+            Err(e) => std::future::ready(Err(e)).into_stream().boxed(),
         }
     }
 
@@ -58,7 +58,7 @@ impl<'c> Executor<'c> for &'c mut ExaConnection {
         'c: 'e,
         E: 'q + Execute<'q, Exasol>,
     {
-        match self._fetch(query) {
+        match self.fetch_impl(query) {
             Ok(stream) => stream
                 .try_filter_map(|v| std::future::ready(Ok(v.right())))
                 .boxed(),
@@ -75,9 +75,9 @@ impl<'c> Executor<'c> for &'c mut ExaConnection {
         'c: 'e,
         E: 'q + Execute<'q, Exasol>,
     {
-        match self._fetch_many(query) {
+        match self.fetch_many_impl(query) {
             Ok(stream) => stream.boxed(),
-            Err(e) => return std::future::ready(Err(e)).into_stream().boxed(),
+            Err(e) => std::future::ready(Err(e)).into_stream().boxed(),
         }
     }
 
@@ -87,7 +87,7 @@ impl<'c> Executor<'c> for &'c mut ExaConnection {
         'c: 'e,
         E: 'q + Execute<'q, Exasol>,
     {
-        let stream = match self._fetch(query) {
+        let stream = match self.fetch_impl(query) {
             Ok(stream) => stream,
             Err(e) => return std::future::ready(Err(e)).boxed(),
         };
@@ -147,7 +147,7 @@ impl<'c> Executor<'c> for &'c mut ExaConnection {
 }
 
 impl ExaConnection {
-    fn _fetch<'c, 'e, 'q, E>(&'c mut self, mut query: E) -> SqlxResult<ResultStream<'e>>
+    fn fetch_impl<'c, 'e, 'q, E>(&'c mut self, mut query: E) -> SqlxResult<ResultStream<'e>>
     where
         'q: 'e,
         'c: 'e,
@@ -167,7 +167,7 @@ impl ExaConnection {
         }
     }
 
-    fn _fetch_many<'c, 'e, 'q, E>(&'c mut self, mut query: E) -> SqlxResult<ResultStream<'e>>
+    fn fetch_many_impl<'c, 'e, 'q, E>(&'c mut self, mut query: E) -> SqlxResult<ResultStream<'e>>
     where
         'q: 'e,
         'c: 'e,

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -449,7 +449,7 @@ mod tests {
             .await?;
 
         query("INSERT INTO CLOSE_RESULTS_TEST VALUES(?)")
-            .bind([1; 10000])
+            .bind(vec![1; 10000])
             .execute(&mut *conn)
             .await?;
 

--- a/src/connection/stream.rs
+++ b/src/connection/stream.rs
@@ -19,7 +19,9 @@ use sqlx_core::{logger::QueryLogger, Either, HashMap};
 use crate::{
     column::ExaColumn,
     connection::websocket::{
-        future::{CloseResultSets, FetchChunk, WebSocketFuture},
+        future::{
+            CloseResultSets, Execute, ExecuteBatch, ExecutePrepared, FetchChunk, WebSocketFuture,
+        },
         ExaWebSocket,
     },
     error::ExaProtocolError,
@@ -33,24 +35,24 @@ use crate::{
 /// from the database.
 ///
 /// This is the top of the hierarchy and the actual type used to stream rows from a [`ResultSet`].
-pub struct ResultStream<'a, F> {
+pub struct ResultStream<'a> {
     ws: &'a mut ExaWebSocket,
     logger: QueryLogger<'a>,
     result_set_handles: Vec<u16>,
-    state: ResultStreamState<F>,
+    state: ResultStreamState<'a>,
     had_err: bool,
 }
 
-impl<'a, F> ResultStream<'a, F>
-where
-    F: WebSocketFuture<Output = MultiResultStream>,
-{
-    pub fn new(ws: &'a mut ExaWebSocket, logger: QueryLogger<'a>, future: F) -> Self {
+impl<'a> ResultStream<'a> {
+    pub fn new<F>(ws: &'a mut ExaWebSocket, logger: QueryLogger<'a>, future: F) -> Self
+    where
+        ResultStreamState<'a>: From<F>,
+    {
         Self {
             ws,
             logger,
             result_set_handles: Vec::new(),
-            state: ResultStreamState::Initial(future),
+            state: future.into(),
             had_err: false,
         }
     }
@@ -59,7 +61,18 @@ where
     fn poll(&mut self, cx: &mut Context<'_>) -> Poll<Option<<Self as Stream>::Item>> {
         loop {
             match &mut self.state {
-                ResultStreamState::Initial(future) => {
+                ResultStreamState::Execute(future) => {
+                    let multi_stream = ready!(future.poll_unpin(cx, self.ws))?;
+                    self.result_set_handles = multi_stream.handles();
+                    self.state = ResultStreamState::Stream(multi_stream);
+                }
+
+                ResultStreamState::ExecuteBatch(future) => {
+                    let multi_stream = ready!(future.poll_unpin(cx, self.ws))?;
+                    self.result_set_handles = multi_stream.handles();
+                    self.state = ResultStreamState::Stream(multi_stream);
+                }
+                ResultStreamState::ExecutePrepared(future) => {
                     let multi_stream = ready!(future.poll_unpin(cx, self.ws))?;
                     self.result_set_handles = multi_stream.handles();
                     self.state = ResultStreamState::Stream(multi_stream);
@@ -84,10 +97,7 @@ where
 
 /// The [`Stream`] implementation here encapsulates end-stages actions such as using the
 /// [`QueryLogger`] or taking note of whether an error occurred (and stop streaming if it did).
-impl<'a, F> Stream for ResultStream<'a, F>
-where
-    F: WebSocketFuture<Output = MultiResultStream>,
-{
+impl<'a> Stream for ResultStream<'a> {
     type Item = SqlxResult<Either<ExaQueryResult, ExaRow>>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -110,7 +120,7 @@ where
     }
 }
 
-impl<'a, F> Drop for ResultStream<'a, F> {
+impl<'a> Drop for ResultStream<'a> {
     fn drop(&mut self) {
         let handles = std::mem::take(&mut self.result_set_handles);
         if !handles.is_empty() {
@@ -122,9 +132,29 @@ impl<'a, F> Drop for ResultStream<'a, F> {
 
 /// State used to distinguish between the initial query execution and the subsequent streaming of
 /// rows.
-enum ResultStreamState<F> {
-    Initial(F),
+pub enum ResultStreamState<'a> {
+    Execute(Execute<'a>),
+    ExecuteBatch(ExecuteBatch<'a>),
+    ExecutePrepared(ExecutePrepared<'a>),
     Stream(MultiResultStream),
+}
+
+impl<'a> From<Execute<'a>> for ResultStreamState<'a> {
+    fn from(value: Execute<'a>) -> Self {
+        Self::Execute(value)
+    }
+}
+
+impl<'a> From<ExecuteBatch<'a>> for ResultStreamState<'a> {
+    fn from(value: ExecuteBatch<'a>) -> Self {
+        Self::ExecuteBatch(value)
+    }
+}
+
+impl<'a> From<ExecutePrepared<'a>> for ResultStreamState<'a> {
+    fn from(value: ExecutePrepared<'a>) -> Self {
+        Self::ExecutePrepared(value)
+    }
 }
 
 /// Helper trait for defining a stream like interface which also accepts a [`ExaWebSocket`]

--- a/src/connection/stream.rs
+++ b/src/connection/stream.rs
@@ -97,7 +97,7 @@ impl<'a> ResultStream<'a> {
 
 /// The [`Stream`] implementation here encapsulates end-stages actions such as using the
 /// [`QueryLogger`] or taking note of whether an error occurred (and stop streaming if it did).
-impl<'a> Stream for ResultStream<'a> {
+impl Stream for ResultStream<'_> {
     type Item = SqlxResult<Either<ExaQueryResult, ExaRow>>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -120,7 +120,7 @@ impl<'a> Stream for ResultStream<'a> {
     }
 }
 
-impl<'a> Drop for ResultStream<'a> {
+impl Drop for ResultStream<'_> {
     fn drop(&mut self) {
         let handles = std::mem::take(&mut self.result_set_handles);
         if !handles.is_empty() {

--- a/src/connection/websocket/future.rs
+++ b/src/connection/websocket/future.rs
@@ -49,7 +49,7 @@ pub struct ExaFuture<'a, T> {
     ws: &'a mut ExaWebSocket,
 }
 
-impl<'a, T> Future for ExaFuture<'a, T>
+impl<T> Future for ExaFuture<'_, T>
 where
     T: WebSocketFuture,
 {
@@ -93,7 +93,7 @@ impl<'a> ExecutePrepared<'a> {
     }
 }
 
-impl<'a> WebSocketFuture for ExecutePrepared<'a> {
+impl WebSocketFuture for ExecutePrepared<'_> {
     type Output = MultiResultStream;
 
     fn poll_unpin(
@@ -248,7 +248,7 @@ impl<'a> ExecuteBatch<'a> {
     }
 }
 
-impl<'a> WebSocketFuture for ExecuteBatch<'a> {
+impl WebSocketFuture for ExecuteBatch<'_> {
     type Output = MultiResultStream;
 
     fn poll_unpin(
@@ -271,7 +271,7 @@ impl<'a> Execute<'a> {
     }
 }
 
-impl<'a> WebSocketFuture for Execute<'a> {
+impl WebSocketFuture for Execute<'_> {
     type Output = MultiResultStream;
 
     fn poll_unpin(
@@ -302,7 +302,7 @@ impl<'a> GetOrPrepare<'a> {
     }
 }
 
-impl<'a> WebSocketFuture for GetOrPrepare<'a> {
+impl WebSocketFuture for GetOrPrepare<'_> {
     type Output = PreparedStatement;
 
     fn poll_unpin(
@@ -396,7 +396,7 @@ impl<'a> Describe<'a> {
     }
 }
 
-impl<'a> WebSocketFuture for Describe<'a> {
+impl WebSocketFuture for Describe<'_> {
     type Output = DescribeStatement;
 
     fn poll_unpin(
@@ -433,7 +433,7 @@ impl<'a> CreatePrepared<'a> {
     }
 }
 
-impl<'a> WebSocketFuture for CreatePrepared<'a> {
+impl WebSocketFuture for CreatePrepared<'_> {
     type Output = PreparedStatement;
 
     fn poll_unpin(

--- a/src/connection/websocket/request.rs
+++ b/src/connection/websocket/request.rs
@@ -322,7 +322,7 @@ pub struct ExaLoginRequest<'a> {
     pub attributes: ExaRwAttributes<'a>,
 }
 
-impl<'a> ExaLoginRequest<'a> {
+impl ExaLoginRequest<'_> {
     /// Encrypts the password with the provided key.
     ///
     /// When connecting using [`Login::Credentials`], Exasol first sends out a public key to encrypt

--- a/src/responses/attributes.rs
+++ b/src/responses/attributes.rs
@@ -254,7 +254,7 @@ impl<'a> ExaRwAttributes<'a> {
     }
 }
 
-impl<'a> Default for ExaRwAttributes<'a> {
+impl Default for ExaRwAttributes<'_> {
     fn default() -> Self {
         Self {
             autocommit: true,

--- a/src/responses/mod.rs
+++ b/src/responses/mod.rs
@@ -120,7 +120,7 @@ impl Parameters {
 fn to_row_major<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Vec<Vec<Value>>, D::Error> {
     struct ColumnVisitor<'a>(&'a mut Vec<Vec<Value>>);
 
-    impl<'de, 'a> Visitor<'de> for ColumnVisitor<'a> {
+    impl<'de> Visitor<'de> for ColumnVisitor<'_> {
         type Value = ();
 
         fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -148,7 +148,7 @@ fn to_row_major<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Vec<Vec<Va
 
     struct Columns<'a>(&'a mut Vec<Vec<Value>>);
 
-    impl<'de, 'a> DeserializeSeed<'de> for Columns<'a> {
+    impl<'de> DeserializeSeed<'de> for Columns<'_> {
         type Value = ();
 
         fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>

--- a/src/types/text.rs
+++ b/src/types/text.rs
@@ -19,7 +19,7 @@ impl<T> Type<Exasol> for Text<T> {
     }
 }
 
-impl<'q, T> Encode<'q, Exasol> for Text<T>
+impl<T> Encode<'_, Exasol> for Text<T>
 where
     T: Display,
 {


### PR DESCRIPTION
Improve the `impl Executor for ExaConnection` to avoid unnecessary boxing and indirection.

Additionally bumps the MSRV and edition because of `https://github.com/RustCrypto/formats/pull/1859`, which is an indirect dependency. Unfortunately this happened right after the `0.8.6` release :/.